### PR TITLE
Support holiday types to ignore

### DIFF
--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -47,6 +47,13 @@ module.exports = class Scheduler {
     return rule
   }
   nowIsHoliday () {
-    return !!new Holidays(process.env.HUBOT_SCHEDULER_LOCALE).isHoliday(new Date())
+    const holiday = new Holidays(process.env.HUBOT_SCHEDULER_LOCALE).isHoliday(new Date())
+    if (!holiday) {
+      return false
+    }
+
+    // public, bank, school, optional or observance
+    const ignores = !!process.env.HUBOT_SCHEDULER_IGNORE_HOLIDAY_TYPES ? process.env.HUBOT_SCHEDULER_IGNORE_HOLIDAY_TYPES.split(',') : []
+    return !ignores.includes(holiday.type)
   }
 }

--- a/test/scheduler.js
+++ b/test/scheduler.js
@@ -27,5 +27,14 @@ describe('Scheduler', function () {
         assert.equal(scheduler.nowIsHoliday(), false)
       })
     })
+    describe('now is holiday but it is set to be ignored', function () {
+      beforeEach(function () {
+        process.env.HUBOT_SCHEDULER_IGNORE_HOLIDAY_TYPES = 'observance'
+        clock = sinon.useFakeTimers(new Date('Fri Nov 15 2019 00:00:00 +0900'))
+      })
+      it('should be false', function () {
+        assert.equal(scheduler.nowIsHoliday(), false)
+      })
+    })
   })
 })


### PR DESCRIPTION
[date-holidays](https://github.com/commenthol/date-holidays) の `isHoliday` 関数の戻り値に含まれている、祝祭日の種類に応じて、その日の祝祭日を無視する設定を追加しました。

例えば、日本時間の 2018/11/15, 2019/11/15 は国民の祝日ではないのですが、 `date-holidays` では[七五三の日として登録](https://github.com/commenthol/date-holidays/blob/aec082ff23c240af0a0db2d55cc408904ec4399b/data/countries/JP.yaml#L284-L288)されており、 `isHoliday() == true` を満たしている状態となり、 `holiday: false` とした場合、投稿がされません。
そこで、以下のように環境変数を設定することで、 11/15 を平日として返せるようにしました。

```
HUBOT_SCHEDULER_IGNORE_HOLIDAY_TYPES=observance
```

どのタイプを無視するかは個人・組織によって異なると思うので、環境変数で設定可能にしました。
よろしくお願いします。