### PR TITLE
fix degrade of previous release

### DIFF
--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -47,13 +47,13 @@ module.exports = class Scheduler {
     return rule
   }
   nowIsHoliday () {
-    const holiday = new Holidays(process.env.HUBOT_SCHEDULER_LOCALE).isHoliday(new Date())
-    if (!holiday) {
+    const holidays = new Holidays(process.env.HUBOT_SCHEDULER_LOCALE).isHoliday(new Date())
+    if (!holidays) {
       return false
     }
 
     // public, bank, school, optional or observance
     const ignores = !!process.env.HUBOT_SCHEDULER_IGNORE_HOLIDAY_TYPES ? process.env.HUBOT_SCHEDULER_IGNORE_HOLIDAY_TYPES.split(',') : []
-    return !ignores.includes(holiday.type)
+    return holidays.every(holiday => !ignores.includes(holiday.type))
   }
 }


### PR DESCRIPTION
## Description 

The last release (#19) has a breaking changes in date-holidays.
This PR includes support for breaking changes that were not included at the time of the last release.

ref: https://github.com/commenthol/date-holidays/blob/master/CHANGELOG.md#200-2021-02-13


## Test

```
yarn run v1.22.19
$ yarn mocha --require intelli-espower-loader
$ /ghq/github.com/rymizuki/hubot-scheduler/node_modules/.bin/mocha --require intelli-espower-loader


  Scheduler
    nowIsHoliday
      now is holiday
        ✓ should be true
      now isnt holidasy
        ✓ should be false
      now is holiday but it is set to be ignored
        ✓ should be false


  3 passing (61ms)

✨  Done in 2.88s.
```